### PR TITLE
Add alternative rules

### DIFF
--- a/game/alternative-rules.md
+++ b/game/alternative-rules.md
@@ -11,7 +11,7 @@ They then have to identity a vulnerability in the system model corresponding to 
 If they are unable to do so, the player clockwise of them gets to attempt to identify a vulnerability.
 This process continues until either a player successfully identifies a vulnerability matching the card or all players have failed to do so.
 
-If a player successfully identifies a vulnerability they should write down the vulnerability they identified, and place the threat card in front of themselves.
+If a player successfully identifies a vulnerability, they should write down the vulnerability they identified and place the threat card in front of themselves.
 The game then continues with the player clockwise of them drawing a new card from the deck.
 
 If no player manages to identify a vulnerability for a card, then the card is removed from play and the player who originally drew it from the deck gets to draw a new card.

--- a/game/alternative-rules.md
+++ b/game/alternative-rules.md
@@ -1,10 +1,10 @@
 ## Elevation of MLSec - Alternate rules
 ### Setup
-Draw a system model where everyone can see it, for example on a whiteboard or on a large screen.
-Ask everyone to set aside skepticism for 15 minutes.
-Remove the front cards (instructions, strategy) and the back (lists of threats), so you only have threat cards, and shuffle those.
-After shuffling, put the deck of cards face down next to the system model.
-Decide the starting player by a method of the group's choice. Simple solutions include having the youngest or tallest player start.
+1. Draw a system model where everyone can see it, for example on a whiteboard or on a large screen. 
+2. Ask everyone to set aside skepticism for 15 minutes. 
+3. Remove the front cards (instructions, strategy) and the back (lists of threats), so you only have threat cards, and shuffle those. 
+4. After shuffling, put the deck of cards face down next to the system model. 
+5. Decide the starting player by a method of the group's choice. Simple solutions include having the youngest or tallest player start.
 ### Playing the game
 The player who gets to start the game will draw the top card of the deck and place it face up next to the system.
 They then have to identity a vulnerability in the system corresponding to the drawn threat.

--- a/game/alternative-rules.md
+++ b/game/alternative-rules.md
@@ -6,8 +6,8 @@
 4. After shuffling, put the deck of cards face down next to the system model. 
 5. Decide the starting player by a method of the group's choice. Simple solutions include having the youngest or tallest player start.
 ### Playing the game
-The player who gets to start the game will draw the top card of the deck and place it face up next to the system.
-They then have to identity a vulnerability in the system corresponding to the drawn threat.
+The player who gets to start the game will draw the top card of the deck and place it face up next to the system model.
+They then have to identity a vulnerability in the system model corresponding to the drawn threat.
 If they are unable to do so, the player clockwise of them gets to attempt to identify a vulnerability.
 This process continues until either a player successfully identifies a vulnerability matching the card or all players have failed to do so.
 

--- a/game/alternative-rules.md
+++ b/game/alternative-rules.md
@@ -1,0 +1,19 @@
+## Elevation of MLSec - Alternate rules
+### Setup
+Draw a system model where everyone can see it, for example on a whiteboard or on a large screen.
+Ask everyone to set aside skepticism for 15 minutes.
+Remove the front cards (instructions, strategy) and the back (lists of threats), so you only have threat cards, and shuffle those.
+After shuffling, put the deck of cards face down next to the system model.
+Decide the starting player by a method of the group's choice. Simple solutions include having the youngest or tallest player start.
+### Playing the game
+The player who gets to start the game will draw the top card of the deck and place it face up next to the system.
+They then have to identity a vulnerability in the system corresponding to the drawn threat.
+If they are unable to do so, the player clockwise of them gets to attempt to identify a vulnerability.
+This process continues until either a player successfully identifies a vulnerability matching the card or all players have failed to do so.
+
+If a player successfully identifies a vulnerability they should write down the vulnerability they identified, and place the threat card in front of themselves.
+The game then continues with the player clockwise of them drawing a new card from the deck.
+
+If no player manages to identify a vulnerability for a card, then the card is removed from play and the player who originally drew it from the deck gets to draw a new card.
+### Ending the game
+The game ends when the deck is empty. The winner of the game is the player who identified the most vulnerabilities, i.e. the player who has the most cards placed in front of themselves.


### PR DESCRIPTION
This pull request adds a variant of the game less focused on the card game part of Elevation of MLSec allowing players to focus more the threat modelling. The point system should incentivize all players to try to identify an applicable risk for each card in the deck.